### PR TITLE
suggest saving to normal dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ShevyJS takes the concepts of the original [Shevy](https://github.com/kyleshevli
 Shevy is available as a module from npm:
 
 ```
-npm install shevyjs --save
+npm install shevyjs
 ```
 
 Or, with Yarn:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ ShevyJS takes the concepts of the original [Shevy](https://github.com/kyleshevli
 Shevy is available as a module from npm:
 
 ```
-npm install shevyjs --save-dev
+npm install shevyjs --save
 ```
 
 Or, with Yarn:
 
 ```
-yarn add shevyjs -D
+yarn add shevyjs
 ```
 
 ### Warning


### PR DESCRIPTION
This library will most likely be built into production, so it makes sense to install it as a normal dependency.